### PR TITLE
Fix constants for testnet

### DIFF
--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -378,12 +378,12 @@ impl Parameters for TestNetwork {
 
     fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
         match nu {
-            NetworkUpgrade::Overwinter => Some(BlockHeight(207_500)),
-            NetworkUpgrade::Sapling => Some(BlockHeight(280_000)),
-            NetworkUpgrade::Blossom => Some(BlockHeight(584_000)),
-            NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
-            NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
-            NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
+            NetworkUpgrade::Overwinter => Some(BlockHeight(1)),
+            NetworkUpgrade::Sapling => Some(BlockHeight(1)),
+            NetworkUpgrade::Blossom => None,
+            NetworkUpgrade::Heartwood => None,
+            NetworkUpgrade::Canopy => None,
+            NetworkUpgrade::Nu5 => None,
             #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => None,
             #[cfg(zcash_unstable = "zfuture")]


### PR DESCRIPTION
These fix an error thrown on synchronizer initialization.  Checkpoint files are referenced (I added these to my SDK branch, will PR later) for the latest checkpoint file.  For us, this is near 1M.  Before attempting to synchronize, an early cheap check is done to see if consensus branchId matches for top height. Because `Heartwood` was expected for this height, we failed to launch synchronizer.

This resolves that error with proper heights for network upgrades.