### PR TITLE
Fix vrsctest prefixes

### DIFF
--- a/components/zcash_protocol/src/constants/vrsc/mainnet.rs
+++ b/components/zcash_protocol/src/constants/vrsc/mainnet.rs
@@ -1,6 +1,6 @@
 //! Constants for the Zcash main network.
 
-/// The mainnet coin type for ZEC, as defined by [SLIP 44].
+/// The mainnet coin type for VRSC, as defined by [SLIP 44].
 ///
 /// [SLIP 44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 pub const COIN_TYPE: u32 = 133;

--- a/components/zcash_protocol/src/constants/vrsc/testnet.rs
+++ b/components/zcash_protocol/src/constants/vrsc/testnet.rs
@@ -1,48 +1,50 @@
 //! Constants for the Zcash test network.
 
-/// The testnet coin type for ZEC, as defined by [SLIP 44].
+/// The mainnet coin type for VRSCTEST, as defined by [SLIP 44].
 ///
 /// [SLIP 44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-pub const COIN_TYPE: u32 = 1;
+pub const COIN_TYPE: u32 = 133;
 
-/// The HRP for a Bech32-encoded testnet Sapling [`ExtendedSpendingKey`].
+/// The HRP for a Bech32-encoded vrsctest Sapling [`ExtendedSpendingKey`].
 ///
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedSpendingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedSpendingKey.html
 /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
-pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-test";
+pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-main";
 
-/// The HRP for a Bech32-encoded testnet Sapling [`ExtendedFullViewingKey`].
+/// The HRP for a Bech32-encoded vrsctest Sapling [`ExtendedFullViewingKey`].
 ///
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedFullViewingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedFullViewingKey.html
 /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
-pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewtestsapling";
+pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviews";
 
-/// The HRP for a Bech32-encoded testnet Sapling [`PaymentAddress`].
+/// The HRP for a Bech32-encoded vrsctest Sapling [`PaymentAddress`].
 ///
 /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
 ///
 /// [`PaymentAddress`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/struct.PaymentAddress.html
 /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
-pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "ztestsapling";
+pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "zs";
 
-/// The prefix for a Base58Check-encoded testnet Sprout address.
+/// The prefix for a Base58Check-encoded vrsctest Sprout address.
 ///
 /// Defined in the [Zcash Protocol Specification section 5.6.3][sproutpaymentaddrencoding].
-pub const B58_SPROUT_ADDRESS_PREFIX: [u8; 1] = [0xb6];
+///
+/// [sproutpaymentaddrencoding]: https://zips.z.cash/protocol/protocol.pdf#sproutpaymentaddrencoding
+pub const B58_SPROUT_ADDRESS_PREFIX: [u8; 1] = [0x9a];
 
-/// The prefix for a Base58Check-encoded testnet transparent [`PublicKeyHash`].
+/// The prefix for a Base58Check-encoded vrsctest transparent [`PublicKeyHash`].
 ///
 /// [`PublicKeyHash`]: https://docs.rs/zcash_primitives/latest/zcash_primitives/legacy/enum.TransparentAddress.html
-pub const B58_PUBKEY_ADDRESS_PREFIX: [u8; 1] = [0x00];
+pub const B58_PUBKEY_ADDRESS_PREFIX: [u8; 1] = [0x3c];
 
-/// The prefix for a Base58Check-encoded testnet transparent [`ScriptHash`].
+/// The prefix for a Base58Check-encoded vrsctest transparent [`ScriptHash`].
 ///
 /// [`ScriptHash`]: https://docs.rs/zcash_primitives/latest/zcash_primitives/legacy/enum.TransparentAddress.html
-pub const B58_SCRIPT_ADDRESS_PREFIX: [u8; 1] = [0x05];
+pub const B58_SCRIPT_ADDRESS_PREFIX: [u8; 1] = [0x55];
 
 /// The HRP for a Bech32m-encoded testnet [ZIP 320] TEX address.
 ///


### PR DESCRIPTION
I had mistakenly used values from `VerusCoin/src/chainparams.cpp` on these, apparently. They are now aligned with mainnet, and thus VRSCTEST.